### PR TITLE
Freeze immutable_struct automatically

### DIFF
--- a/lib/upgrow/immutable_struct.rb
+++ b/lib/upgrow/immutable_struct.rb
@@ -30,6 +30,7 @@ module Upgrow
     def initialize(**args)
       members.each { |key| args.fetch(key) }
       super(**args)
+      freeze
     end
   end
 end

--- a/test/upgrow/immutable_struct_test.rb
+++ b/test/upgrow/immutable_struct_test.rb
@@ -11,6 +11,7 @@ module Upgrow
 
       assert_equal([:user, :post], struct.members)
       assert_equal(['volmer', 'hello'], struct.values)
+      assert struct.frozen?
     end
 
     test 'it does not respond to []=' do


### PR DESCRIPTION
I know it removed all the setter methods, but we then we can also freeze it, so it's more friendly for Ruby runtime that it's immutable. It's obvious for human but not necessarily obvious for Ruby.