### PR TITLE
[Proposal] Accept Symbol only on initialization of ImmutableStruct

### DIFF
--- a/lib/upgrow/immutable_struct.rb
+++ b/lib/upgrow/immutable_struct.rb
@@ -11,6 +11,10 @@ module Upgrow
       # @return [ImmutableStruct] the new Immutable Struct class able to
       #   accommodate the given members.
       def new(*args, &block)
+        if args.any? { |member| !member.is_a?(Symbol) }
+          raise ArgumentError, 'all members must be symbols'
+        end
+
         struct_class = super(*args, keyword_init: true, &block)
 
         struct_class.members.each do |member|

--- a/test/upgrow/immutable_struct_test.rb
+++ b/test/upgrow/immutable_struct_test.rb
@@ -14,6 +14,14 @@ module Upgrow
       assert struct.frozen?
     end
 
+    test '.new accepts symbols only' do
+      error = assert_raises(ArgumentError) do
+        ImmutableStruct.new('Shopify', :user, :post)
+      end
+
+      assert_equal 'all members must be symbols', error.message
+    end
+
     test 'it does not respond to []=' do
       struct = ImmutableStruct.new(:user).new(user: 'volmer')
       refute struct.respond_to?(:[]=)


### PR DESCRIPTION
Unlike its YARD, `Upgrow::ImmutableStruct.new` can accept `String` and possibly returns `ImmutableStruct::<SomeSubClass>`.

Because the `Struct` class accepts not only `Symbol` but also `String` on initialization. Besides, if the first argument is eligible for a class name, it creates a new structure class with the name under Struct.

```ruby
Struct.new("Customer", :name, :address)
=> Struct::Customer
```

ref https://ruby-doc.org/core-3.0.0/Struct.html#method-c-new

However, this behavior is a bit confusing and makes its interface a bit complicated (I assume the Struct behavior is just for backward compatibility.). So this pull request is trying to add a more strict type check on initialization.

It's just a proposal though, what do you think?

### Before

```ruby
> Upgrow::ImmutableStruct.new('Dog', :name)
=> ImmutableStruct::Dog(keyword_init: true)
```

### After

```ruby
> Upgrow::ImmutableStruct.new('Dog', :name)
Traceback (most recent call last):
        5: from /Users/ohbarye/.rbenv/versions/2.7.1/bin/irb:23:in `<main>'
        4: from /Users/ohbarye/.rbenv/versions/2.7.1/bin/irb:23:in `load'
        3: from /Users/ohbarye/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
        2: from (irb):102
        1: from (irb):75:in `new'
ArgumentError (all members must be symbols)
```