### PR TITLE
Rails generators for Upgrow patterns

### DIFF
--- a/docs/guide/the-missing-pieces.md
+++ b/docs/guide/the-missing-pieces.md
@@ -757,7 +757,7 @@ the controller as follows:
 class ArticlesController < ApplicationController
  # GET /articles
  def index
-   @articles = ListArticlesAction.new.perform.articles
+   @articles = ListArticleAction.new.perform.articles
  end
 
  # GET /articles/1

--- a/lib/generators/upgrow_scaffold/USAGE
+++ b/lib/generators/upgrow_scaffold/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    bin/rails generate upgrow_scaffold Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/upgrow_scaffold/USAGE
+++ b/lib/generators/upgrow_scaffold/USAGE
@@ -1,8 +1,8 @@
 Description:
-    Explain the generator
+    Generate scaffolding using the Upgrow patterns.
 
-Example:
-    bin/rails generate upgrow_scaffold Thing
-
-    This will create:
-        what/will/it/create
+Examples:
+    `bin/rails generate upgrow_scaffold post`
+    `bin/rails generate upgrow_scaffold post title:string body:text published:boolean`
+    `bin/rails generate upgrow_scaffold purchase amount:decimal tracking_id:integer:uniq`
+    `bin/rails generate upgrow_scaffold user email:uniq password:digest`

--- a/lib/generators/upgrow_scaffold/templates/controller.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/controller.rb.tt
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class <%= controller_class_name %>Controller < ApplicationController
+  def index
+    @<%= plural_name %> = List<%= class_name %>Action.new.perform.<%= plural_name %>
+  end
+
+  def show
+    @<%= singular_name %> = Show<%= class_name %>Action.new.perform(params[:id]).<%= singular_name %>
+  end
+
+  def new
+    @input = <%= input_class_name %>.new
+  end
+
+  def edit
+    <%= singular_name %> = Edit<%= class_name %>Action.new.perform(params[:id]).<%= singular_name %>
+    @input = <%= input_class_name %>.new(
+      <%= attributes_as_model_args_for_method_params %>
+    )
+  end
+
+  def create
+    @input = <%= input_class_name %>.new(<%= singular_name %>_params)
+
+    Create<%= class_name %>Action.new.perform(@input)
+      .and_then do |<%= singular_name %>:|
+        redirect_to(
+          <%= singular_name %>_path(<%= singular_name %>.id), notice: '<%= class_name %> was successfully created.'
+        )
+      end
+      .or_else do |errors|
+        @errors = errors
+        render(:new)
+      end
+  end
+
+  def update
+    @input = <%= input_class_name %>.new(<%= singular_name %>_params)
+
+    Update<%= class_name %>Action.new.perform(params[:id], @input)
+      .and_then do |<%= singular_name %>:|
+        redirect_to(
+          <%= singular_name %>_path(<%= singular_name %>.id),
+          notice: '<%= class_name %> was successfully updated.'
+        )
+      end
+      .or_else do |errors|
+        @errors = errors
+        render(:edit)
+      end
+  end
+
+  def destroy
+    Delete<%= class_name %>Action.new.perform(params[:id])
+    redirect_to(<%= plural_name %>_url, notice: '<%= class_name %> was successfully destroyed.')
+  end
+
+  private
+
+  def <%= singular_name %>_params
+    params.require(:<%= singular_name %>_input).permit(<%= attributes_as_symbols_for_method_params %>)
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/create_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/create_action.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Create<%= class_name %>Action < Upgrow::Action
   result :<%=singular_name %>
 

--- a/lib/generators/upgrow_scaffold/templates/create_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/create_action.rb.tt
@@ -1,0 +1,12 @@
+class Create<%= class_name %>Action < Upgrow::Action
+  result :<%=singular_name %>
+
+  def perform(input)
+    if input.valid?
+      <%=singular_name %> = <%= repository_class_name %>.new.create(input)
+      result.success(<%=singular_name %>: <%=singular_name %>)
+    else
+      result.failure(input.errors)
+    end
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/delete_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/delete_action.rb.tt
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Delete<%= class_name %>Action < Upgrow::Action
+  def perform(id)
+    <%= repository_class_name %>.new.delete(id)
+    result.success
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/edit_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/edit_action.rb.tt
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Edit<%= class_name %>Action < Upgrow::Action
+  result :<%= singular_name %>
+
+  def perform(id)
+    article = <%= repository_class_name %>.new.find(id)
+
+    result.success(<%= singular_name %>: <%= singular_name %>)
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/input.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/input.rb.tt
@@ -1,5 +1,7 @@
-class <%= class_name %>Input
-  include ActiveModel::Model
+# frozen_string_literal: true
 
-  attr_accessor <%= attributes_as_symbols_for_method_params %>
+class <%= class_name %>Input < Upgrow::Input
+<% attributes_names.each do|attribute| -%>
+  attribute :<%= attribute %>
+<% end -%>
 end

--- a/lib/generators/upgrow_scaffold/templates/input.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/input.rb.tt
@@ -1,0 +1,5 @@
+class <%= class_name %>Input
+  include ActiveModel::Model
+
+  attr_accessor <%= attributes_as_symbols_for_method_params %>
+end

--- a/lib/generators/upgrow_scaffold/templates/list_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/list_action.rb.tt
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class List<%= class_name %>Action < Upgrow::Action
+  result :<%= plural_name %>
+
+  def perform
+    result.success(<%= plural_name %>: <%= repository_class_name %>.new.all)
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/model.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/model.rb.tt
@@ -1,12 +1,7 @@
-class <%= class_name %>
-  attr_reader :id, <%= attributes_as_symbols_for_method_params %>, :created_at, :updated_at
+# frozen_string_literal: true
 
-  def initialize(id:, <%= attributes_as_keyword_args_for_method_signature %>, created_at:, updated_at:)
-    @id = id
+class <%= class_name %> < Upgrow::Model
 <% attributes_names.each do|attribute| -%>
-    @<%= attribute %> = <%= attribute %>
+  attribute :<%= attribute %>
 <% end -%>
-    @created_at = created_at
-    @updated_at = updated_at
-  end
 end

--- a/lib/generators/upgrow_scaffold/templates/model.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/model.rb.tt
@@ -1,0 +1,12 @@
+class <%= class_name %>
+  attr_reader :id, <%= attributes_as_symbols_for_method_params %>, :created_at, :updated_at
+
+  def initialize(id:, <%= attributes_as_keyword_args_for_method_signature %>, created_at:, updated_at:)
+    @id = id
+<% attributes_names.each do|attribute| -%>
+    @<%= attribute %> = <%= attribute %>
+<% end -%>
+    @created_at = created_at
+    @updated_at = updated_at
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/record.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/record.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= record_class_name %> < <%= parent_class_name_for_records %>
   self.table_name = '<%= class_name.tableize %>'
 end

--- a/lib/generators/upgrow_scaffold/templates/record.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/record.rb.tt
@@ -1,3 +1,3 @@
-class <%= class_name %>Record < <%= parent_class_name_for_records %>
+class <%= record_class_name %> < <%= parent_class_name_for_records %>
   self.table_name = '<%= class_name.tableize %>'
 end

--- a/lib/generators/upgrow_scaffold/templates/record.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/record.rb.tt
@@ -1,0 +1,3 @@
+class <%= class_name %>Record < <%= parent_class_name_for_records %>
+  self.table_name = '<%= class_name.tableize %>'
+end

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -1,4 +1,4 @@
-class <%= class_name%>Repository
+class <%= repository_class_name %>
   def all
     <%= record_class_name %>.all.map { |record| to_model(record.attributes) }
   end

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= repository_class_name %>
   def all
     <%= record_class_name %>.all.map { |record| to_model(record.attributes) }

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -1,0 +1,24 @@
+class <%= class_name%>Repository
+  def all
+    <%= record_class_name %>.all
+  end
+
+  def create(title:, body:)
+    <%= record_class_name %>.create!(title: title, body: body)
+  end
+
+  def find(id)
+    <%= record_class_name %>.find(id)
+  end
+
+  def update(id, title:, body:)
+    record = find(id)
+    record.update!(title: title, body: body)
+    record
+  end
+
+  def delete(id)
+    record = find(id)
+    record.destroy!
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -1,24 +1,32 @@
 class <%= class_name%>Repository
   def all
-    <%= record_class_name %>.all
+    <%= record_class_name %>.all.map { |record| to_model(record.attributes) }
   end
 
   def create(input)
-    <%= record_class_name %>.create!(<%= attributes_as_input_args_for_method_params %>)
+    record = <%= record_class_name %>.create!(<%= attributes_as_input_args_for_method_params %>)
+    to_model(record.attributes)
   end
 
   def find(id)
-    <%= record_class_name %>.find(id)
+    record = <%= record_class_name %>.find(id)
+    to_model(record.attributes)
   end
 
   def update(id, input)
-    record = find(id)
+    record = <%= record_class_name %>.find(id)
     record.update!(<%= attributes_as_input_args_for_method_params %>)
-    record
+    to_model(record.attributes)
   end
 
   def delete(id)
-    record = find(id)
+    record = <%= record_class_name %>.find(id)
     record.destroy!
+  end
+
+  private
+
+  def to_model(attributes)
+    <%= class_name %>.new(**attributes.symbolize_keys)
   end
 end

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -3,17 +3,17 @@ class <%= class_name%>Repository
     <%= record_class_name %>.all
   end
 
-  def create(title:, body:)
-    <%= record_class_name %>.create!(title: title, body: body)
+  def create(<%= attributes_as_keyword_args_for_method_signature %>)
+    <%= record_class_name %>.create!(<%= attributes_as_keyword_args_for_method_params %>)
   end
 
   def find(id)
     <%= record_class_name %>.find(id)
   end
 
-  def update(id, title:, body:)
+  def update(id, <%= attributes_as_keyword_args_for_method_signature %>)
     record = find(id)
-    record.update!(title: title, body: body)
+    record.update!(<%= attributes_as_keyword_args_for_method_params %>)
     record
   end
 

--- a/lib/generators/upgrow_scaffold/templates/repository.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/repository.rb.tt
@@ -3,17 +3,17 @@ class <%= class_name%>Repository
     <%= record_class_name %>.all
   end
 
-  def create(<%= attributes_as_keyword_args_for_method_signature %>)
-    <%= record_class_name %>.create!(<%= attributes_as_keyword_args_for_method_params %>)
+  def create(input)
+    <%= record_class_name %>.create!(<%= attributes_as_input_args_for_method_params %>)
   end
 
   def find(id)
     <%= record_class_name %>.find(id)
   end
 
-  def update(id, <%= attributes_as_keyword_args_for_method_signature %>)
+  def update(id, input)
     record = find(id)
-    record.update!(<%= attributes_as_keyword_args_for_method_params %>)
+    record.update!(<%= attributes_as_input_args_for_method_params %>)
     record
   end
 

--- a/lib/generators/upgrow_scaffold/templates/show_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/show_action.rb.tt
@@ -1,0 +1,7 @@
+class Show<%= class_name %>Action < Upgrow::Action
+  result :<%= singular_name %>
+
+  def perform(id)
+    result.success(<%= singular_name %>: <%=repository_class_name %>.new.find(id))
+  end
+end

--- a/lib/generators/upgrow_scaffold/templates/show_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/show_action.rb.tt
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 class Show<%= class_name %>Action < Upgrow::Action
   result :<%= singular_name %>
 
   def perform(id)
-    result.success(<%= singular_name %>: <%=repository_class_name %>.new.find(id))
+    <%= singular_name %> = <%=repository_class_name %>.new.find(id)
+
+    result.success(<%= singular_name %>: <%= singular_name %>)
   end
 end

--- a/lib/generators/upgrow_scaffold/templates/update_action.rb.tt
+++ b/lib/generators/upgrow_scaffold/templates/update_action.rb.tt
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Update<%= class_name %>Action < Upgrow::Action
+  result :<%= singular_name %>
+
+  def perform(id, input)
+    if input.valid?
+      <%= singular_name %> = <%= repository_class_name %>.new.update(id, input)
+      result.success(<%= singular_name %>: <%= singular_name %>)
+    else
+      result.failure(input.errors)
+    end
+  end
+end

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -27,6 +27,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('show_action.rb', "app/actions/show_#{singular_name}_action.rb")
   end
 
+  def create_create_action
+    template('create_action.rb', "app/actions/create_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -35,6 +35,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('delete_action.rb', "app/actions/delete_#{singular_name}_action.rb")
   end
 
+  def create_edit_action
+    template('edit_action.rb', "app/actions/edit_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -29,15 +29,9 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     "#{class_name}Record"
   end
 
-  def attributes_as_keyword_args_for_method_signature
+  def attributes_as_input_args_for_method_params
     attributes_names.map do |attribute|
-      "#{attribute}:"
-    end.join(', ')
-  end
-
-  def attributes_as_keyword_args_for_method_params
-    attributes_names.map do |attribute|
-      "#{attribute}: #{attribute}"
+      "#{attribute}: input.#{attribute}"
     end.join(', ')
   end
 

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -15,6 +15,9 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('repository.rb', "app/repositories/#{file_name.pluralize}_repository.rb")
   end
 
+  def create_input
+    template('input.rb', "app/inputs/#{file_name}_input.rb")
+  end
 
   private
 
@@ -35,6 +38,12 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
   def attributes_as_keyword_args_for_method_params
     attributes_names.map do |attribute|
       "#{attribute}: #{attribute}"
+    end.join(', ')
+  end
+
+  def attributes_as_symbols_for_method_params
+    attributes_names.map do |attribute|
+      ":#{attribute}"
     end.join(', ')
   end
 end

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -1,0 +1,3 @@
+class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+end

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -19,6 +19,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('input.rb', "app/inputs/#{file_name}_input.rb")
   end
 
+  def create_model
+    template('model.rb', "app/models/#{file_name}.rb")
+  end
+
   private
 
   def parent_class_name_for_records
@@ -27,6 +31,12 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
 
   def record_class_name
     "#{class_name}Record"
+  end
+
+  def attributes_as_keyword_args_for_method_signature
+    attributes_names.map do |attribute|
+      "#{attribute}:"
+    end.join(', ')
   end
 
   def attributes_as_input_args_for_method_params

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -6,9 +6,18 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('record.rb', "app/records/#{file_name}_record.rb")
   end
 
+  def create_repository
+    template('repository.rb', "app/repositories/#{file_name.pluralize}_repository.rb")
+  end
+
+
   private
 
   def parent_class_name_for_records
     'ApplicationRecord'
+  end
+
+  def record_class_name
+    "#{class_name}Record"
   end
 end

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -39,6 +39,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('edit_action.rb', "app/actions/edit_#{singular_name}_action.rb")
   end
 
+  def create_list_action
+    template('list_action.rb', "app/actions/list_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -1,7 +1,7 @@
 require "rails/generators/model_helpers"
 
 class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
-  include Rails::Generators::ModelHelpers
+  include Rails::Generators::ResourceHelpers
 
   source_root File.expand_path('templates', __dir__)
   argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
@@ -47,6 +47,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('update_action.rb', "app/actions/update_#{singular_name}_action.rb")
   end
 
+  def create_controller
+    template('controller.rb', "app/controllers/#{controller_name}_controller.rb")
+  end
+
   private
 
   def parent_class_name_for_records
@@ -61,6 +65,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     "#{class_name}Repository"
   end
 
+  def input_class_name
+    "#{class_name}Input"
+  end
+
   def attributes_as_keyword_args_for_method_signature
     attributes_names.map do |attribute|
       "#{attribute}:"
@@ -70,6 +78,12 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
   def attributes_as_input_args_for_method_params
     attributes_names.map do |attribute|
       "#{attribute}: input.#{attribute}"
+    end.join(', ')
+  end
+
+  def attributes_as_model_args_for_method_params
+    attributes_names.map do |attribute|
+      "#{attribute}: #{singular_name}.#{attribute}"
     end.join(', ')
   end
 

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -12,7 +12,7 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
   end
 
   def create_repository
-    template('repository.rb', "app/repositories/#{file_name.pluralize}_repository.rb")
+    template('repository.rb', "app/repositories/#{file_name}_repository.rb")
   end
 
   def create_input

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -23,6 +23,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('model.rb', "app/models/#{file_name}.rb")
   end
 
+  def create_show_action
+    template('show_action.rb', "app/actions/show_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records
@@ -31,6 +35,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
 
   def record_class_name
     "#{class_name}Record"
+  end
+
+  def repository_class_name
+    "#{class_name}Repository"
   end
 
   def attributes_as_keyword_args_for_method_signature

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -31,6 +31,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('create_action.rb', "app/actions/create_#{singular_name}_action.rb")
   end
 
+  def create_delete_action
+    template('delete_action.rb', "app/actions/delete_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -43,6 +43,10 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
     template('list_action.rb', "app/actions/list_#{singular_name}_action.rb")
   end
 
+  def create_update_action
+    template('update_action.rb', "app/actions/update_#{singular_name}_action.rb")
+  end
+
   private
 
   def parent_class_name_for_records

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -1,3 +1,14 @@
 class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('templates', __dir__)
+
+  # When a generator is invoked, each public method in the generator is executed sequentially in the order that it is defined.
+  def create_record
+    template('record.rb', "app/records/#{file_name}_record.rb")
+  end
+
+  private
+
+  def parent_class_name_for_records
+    'ApplicationRecord'
+  end
 end

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -1,5 +1,3 @@
-require "rails/generators/model_helpers"
-
 class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
   include Rails::Generators::ResourceHelpers
 

--- a/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
+++ b/lib/generators/upgrow_scaffold/upgrow_scaffold_generator.rb
@@ -1,5 +1,10 @@
+require "rails/generators/model_helpers"
+
 class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::ModelHelpers
+
   source_root File.expand_path('templates', __dir__)
+  argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
   # When a generator is invoked, each public method in the generator is executed sequentially in the order that it is defined.
   def create_record
@@ -19,5 +24,17 @@ class UpgrowScaffoldGenerator < Rails::Generators::NamedBase
 
   def record_class_name
     "#{class_name}Record"
+  end
+
+  def attributes_as_keyword_args_for_method_signature
+    attributes_names.map do |attribute|
+      "#{attribute}:"
+    end.join(', ')
+  end
+
+  def attributes_as_keyword_args_for_method_params
+    attributes_names.map do |attribute|
+      "#{attribute}: #{attribute}"
+    end.join(', ')
   end
 end

--- a/test/dummy/app/actions/create_article_action.rb
+++ b/test/dummy/app/actions/create_article_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateArticleAction < Upgrow::Action
   result :article
 

--- a/test/dummy/app/actions/delete_article_action.rb
+++ b/test/dummy/app/actions/delete_article_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class DeleteArticleAction < Upgrow::Action
   def perform(id)
     ArticleRepository.new.delete(id)

--- a/test/dummy/app/actions/edit_article_action.rb
+++ b/test/dummy/app/actions/edit_article_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class EditArticleAction < Upgrow::Action
   result :article
 

--- a/test/dummy/app/actions/list_article_action.rb
+++ b/test/dummy/app/actions/list_article_action.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ListArticlesAction < Upgrow::Action
+class ListArticleAction < Upgrow::Action
   result :articles
 
   def perform

--- a/test/dummy/app/actions/list_articles_action.rb
+++ b/test/dummy/app/actions/list_articles_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ListArticlesAction < Upgrow::Action
   result :articles
 

--- a/test/dummy/app/actions/show_article_action.rb
+++ b/test/dummy/app/actions/show_article_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ShowArticleAction < Upgrow::Action
   result :article
 

--- a/test/dummy/app/actions/update_article_action.rb
+++ b/test/dummy/app/actions/update_article_action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class UpdateArticleAction < Upgrow::Action
   result :article
 

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@
 
 class ArticlesController < ApplicationController
   def index
-    @articles = ListArticlesAction.new.perform.articles
+    @articles = ListArticleAction.new.perform.articles
   end
 
   def show

--- a/test/dummy/app/inputs/article_input.rb
+++ b/test/dummy/app/inputs/article_input.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ArticleInput < Upgrow::Input
   attribute :title
   attribute :body

--- a/test/dummy/app/repositories/article_repository.rb
+++ b/test/dummy/app/repositories/article_repository.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ArticleRepository
   def all
     ArticleRecord.all.map do |record|

--- a/test/dummy/app/repositories/article_repository.rb
+++ b/test/dummy/app/repositories/article_repository.rb
@@ -2,9 +2,7 @@
 
 class ArticleRepository
   def all
-    ArticleRecord.all.map do |record|
-      to_model(record.attributes)
-    end
+    ArticleRecord.all.map { |record| to_model(record.attributes) }
   end
 
   def create(input)

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -10,6 +10,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   def files_expected_to_be_created_by_generator
     %w(
       app/actions/create_article_action.rb
+      app/actions/delete_article_action.rb
       app/actions/show_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -15,6 +15,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     files_created_by_generator = (files_after_generator - files_before_generator).sort
     expected_files_created_by_generator = %w(
       app/inputs/article_input.rb
+      app/models/article.rb
       app/records/article_record.rb
       app/repositories/articles_repository.rb
     )
@@ -79,6 +80,29 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
         include ActiveModel::Model
 
         attr_accessor :title, :body
+      end
+      EXPECTED_CONTENT
+
+      assert_equal expected_content, generated_content
+    end
+  end
+
+
+  test "generator creates app/models/article.rb" do
+    run_generator
+
+    assert_file 'app/models/article.rb' do |generated_content|
+      expected_content = <<~EXPECTED_CONTENT
+      class Article
+        attr_reader :id, :title, :body, :created_at, :updated_at
+
+        def initialize(id:, title:, body:, created_at:, updated_at:)
+          @id = id
+          @title = title
+          @body = body
+          @created_at = created_at
+          @updated_at = updated_at
+        end
       end
       EXPECTED_CONTENT
 

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -18,6 +18,12 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     )
   end
 
+  def dummy_app_files_with_content_that_is_not_from_generator
+    {
+      'app/inputs/article_input.rb' => "\n\n  validates :title, presence: true\n  validates :body, presence: true, length: { minimum: 10 }"
+    }
+  end
+
   def files_in_generator_destination
     Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
   end
@@ -38,13 +44,9 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       test_dummy_app_file_path = 'test/dummy/' + generated_file_file_path
 
       expected_content = File.read(test_dummy_app_file_path)
+      content_to_exclude = dummy_app_files_with_content_that_is_not_from_generator[generated_file_file_path]
 
-      if generated_file_file_path.match?(/inputs\/article_input.rb$/)
-        content_to_exclude = <<-EXCLUDE_WITH_WHITESPACE
-
-  validates :title, presence: true
-  validates :body, presence: true, length: { minimum: 10 }
-          EXCLUDE_WITH_WHITESPACE
+      if content_to_exclude
         expected_content = expected_content.gsub(content_to_exclude, '')
       end
 

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -14,6 +14,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
 
     files_created_by_generator = (files_after_generator - files_before_generator).sort
     expected_files_created_by_generator = %w(
+      app/actions/show_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb
       app/records/article_record.rb
@@ -112,6 +113,24 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     end
     EXPECTED_CONTENT
     assert_file 'app/models/article.rb' do |generated_content|
+      assert_equal expected_content, generated_content
+    end
+  end
+
+  test "generator creates app/actions/show_article_action.rb" do
+    run_generator
+
+    expected_content = <<~EXPECTED_CONTENT
+    class ShowArticleAction < Upgrow::Action
+      result :article
+
+      def perform(id)
+        result.success(article: ArticleRepository.new.find(id))
+      end
+    end
+    EXPECTED_CONTENT
+
+    assert_file 'app/actions/show_article_action.rb' do |generated_content|
       assert_equal expected_content, generated_content
     end
   end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -15,6 +15,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       app/actions/list_article_action.rb
       app/actions/show_article_action.rb
       app/actions/update_article_action.rb
+      app/controllers/articles_controller.rb
       app/inputs/article_input.rb
       app/models/article.rb
       app/records/article_record.rb

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -14,6 +14,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       app/actions/edit_article_action.rb
       app/actions/list_article_action.rb
       app/actions/show_article_action.rb
+      app/actions/update_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb
       app/records/article_record.rb

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -36,7 +36,17 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
 
     files_expected_to_be_created_by_generator.each do |generated_file_file_path|
       test_dummy_app_file_path = 'test/dummy/' + generated_file_file_path
+
       expected_content = File.read(test_dummy_app_file_path)
+
+      if generated_file_file_path.match?(/inputs\/article_input.rb$/)
+        content_to_exclude = <<-EXCLUDE_WITH_WHITESPACE
+
+  validates :title, presence: true
+  validates :body, presence: true, length: { minimum: 10 }
+          EXCLUDE_WITH_WHITESPACE
+        expected_content = expected_content.gsub(content_to_exclude, '')
+      end
 
       assert_file generated_file_file_path do |generated_content|
         assert_equal expected_content, generated_content

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -14,6 +14,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
 
     files_created_by_generator = (files_after_generator - files_before_generator).sort
     expected_files_created_by_generator = %w(
+      app/inputs/article_input.rb
       app/records/article_record.rb
       app/repositories/articles_repository.rb
     )
@@ -62,6 +63,22 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
           record = find(id)
           record.destroy!
         end
+      end
+      EXPECTED_CONTENT
+
+      assert_equal expected_content, generated_content
+    end
+  end
+
+  test "generator creates app/inputs/article_input.rb" do
+    run_generator
+
+    assert_file 'app/inputs/article_input.rb' do |generated_content|
+      expected_content = <<~EXPECTED_CONTENT
+      class ArticleInput
+        include ActiveModel::Model
+
+        attr_accessor :title, :body
       end
       EXPECTED_CONTENT
 

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -12,6 +12,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       app/actions/create_article_action.rb
       app/actions/delete_article_action.rb
       app/actions/edit_article_action.rb
+      app/actions/list_article_action.rb
       app/actions/show_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -45,17 +45,17 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
           ArticleRecord.all
         end
 
-        def create(title:, body:)
-          ArticleRecord.create!(title: title, body: body)
+        def create(input)
+          ArticleRecord.create!(title: input.title, body: input.body)
         end
 
         def find(id)
           ArticleRecord.find(id)
         end
 
-        def update(id, title:, body:)
+        def update(id, input)
           record = find(id)
-          record.update!(title: title, body: body)
+          record.update!(title: input.title, body: input.body)
           record
         end
 

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -11,6 +11,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     %w(
       app/actions/create_article_action.rb
       app/actions/delete_article_action.rb
+      app/actions/edit_article_action.rb
       app/actions/show_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -7,13 +7,8 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
   arguments %w(article title:string body:text)
 
-  test "generator creates only expected files" do
-    files_before_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
-    run_generator
-    files_after_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
-
-    files_created_by_generator = (files_after_generator - files_before_generator).sort
-    expected_files_created_by_generator = %w(
+  def files_expected_to_be_created_by_generator
+    %w(
       app/actions/create_article_action.rb
       app/actions/show_article_action.rb
       app/inputs/article_input.rb
@@ -21,7 +16,15 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       app/records/article_record.rb
       app/repositories/articles_repository.rb
     )
-    assert_equal expected_files_created_by_generator, files_created_by_generator
+  end
+
+  test "generator creates only expected files" do
+    files_before_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+    run_generator
+    files_after_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+
+    files_created_by_generator = (files_after_generator - files_before_generator).sort
+    assert_equal files_expected_to_be_created_by_generator, files_created_by_generator
   end
 
   test "generator creates app/records/article_record.rb" do

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require "rails_helper"
 require "generators/upgrow_scaffold/upgrow_scaffold_generator"
 
 class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -43,26 +43,34 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       expected_content = <<~EXPECTED_CONTENT
       class ArticleRepository
         def all
-          ArticleRecord.all
+          ArticleRecord.all.map { |record| to_model(record.attributes) }
         end
 
         def create(input)
-          ArticleRecord.create!(title: input.title, body: input.body)
+          record = ArticleRecord.create!(title: input.title, body: input.body)
+          to_model(record.attributes)
         end
 
         def find(id)
-          ArticleRecord.find(id)
+          record = ArticleRecord.find(id)
+          to_model(record.attributes)
         end
 
         def update(id, input)
-          record = find(id)
+          record = ArticleRecord.find(id)
           record.update!(title: input.title, body: input.body)
-          record
+          to_model(record.attributes)
         end
 
         def delete(id)
-          record = find(id)
+          record = ArticleRecord.find(id)
           record.destroy!
+        end
+
+        private
+
+        def to_model(attributes)
+          Article.new(**attributes.symbolize_keys)
         end
       end
       EXPECTED_CONTENT

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require "generators/upgrow_scaffold/upgrow_scaffold_generator"
+
+class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
+  tests UpgrowScaffoldGenerator
+  destination Rails.root.join('tmp/generators')
+  setup :prepare_destination
+
+  # test "generator runs without errors" do
+  #   assert_nothing_raised do
+  #     run_generator ["arguments"]
+  #   end
+  # end
+end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -31,138 +31,16 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_equal files_expected_to_be_created_by_generator, files_created_by_generator
   end
 
-  test "generator creates app/records/article_record.rb" do
+  test "generator creates same files as the dummy app" do
     run_generator
 
-    expected_content = <<~EXPECTED_CONTENT
-    class ArticleRecord < ApplicationRecord
-      self.table_name = 'articles'
-    end
-    EXPECTED_CONTENT
+    files_expected_to_be_created_by_generator.each do |generated_file_file_path|
+      test_dummy_app_file_path = 'test/dummy/' + generated_file_file_path
+      expected_content = File.read(test_dummy_app_file_path)
 
-    assert_file 'app/records/article_record.rb' do |generated_content|
-      assert_equal expected_content, generated_content
-    end
-  end
-
-  test "generator creates app/repositories/articles_repository.rb" do
-    run_generator
-
-    expected_content = <<~EXPECTED_CONTENT
-    class ArticleRepository
-      def all
-        ArticleRecord.all.map { |record| to_model(record.attributes) }
+      assert_file generated_file_file_path do |generated_content|
+        assert_equal expected_content, generated_content
       end
-
-      def create(input)
-        record = ArticleRecord.create!(title: input.title, body: input.body)
-        to_model(record.attributes)
-      end
-
-      def find(id)
-        record = ArticleRecord.find(id)
-        to_model(record.attributes)
-      end
-
-      def update(id, input)
-        record = ArticleRecord.find(id)
-        record.update!(title: input.title, body: input.body)
-        to_model(record.attributes)
-      end
-
-      def delete(id)
-        record = ArticleRecord.find(id)
-        record.destroy!
-      end
-
-      private
-
-      def to_model(attributes)
-        Article.new(**attributes.symbolize_keys)
-      end
-    end
-    EXPECTED_CONTENT
-
-    assert_file 'app/repositories/articles_repository.rb' do |generated_content|
-      assert_equal expected_content, generated_content
-    end
-  end
-
-  test "generator creates app/inputs/article_input.rb" do
-    run_generator
-
-    expected_content = <<~EXPECTED_CONTENT
-    class ArticleInput
-      include ActiveModel::Model
-
-      attr_accessor :title, :body
-    end
-    EXPECTED_CONTENT
-
-    assert_file 'app/inputs/article_input.rb' do |generated_content|
-      assert_equal expected_content, generated_content
-    end
-  end
-
-
-  test "generator creates app/models/article.rb" do
-    run_generator
-    expected_content = <<~EXPECTED_CONTENT
-    class Article
-      attr_reader :id, :title, :body, :created_at, :updated_at
-
-      def initialize(id:, title:, body:, created_at:, updated_at:)
-        @id = id
-        @title = title
-        @body = body
-        @created_at = created_at
-        @updated_at = updated_at
-      end
-    end
-    EXPECTED_CONTENT
-    assert_file 'app/models/article.rb' do |generated_content|
-      assert_equal expected_content, generated_content
-    end
-  end
-
-  test "generator creates app/actions/show_article_action.rb" do
-    run_generator
-
-    expected_content = <<~EXPECTED_CONTENT
-    class ShowArticleAction < Upgrow::Action
-      result :article
-
-      def perform(id)
-        result.success(article: ArticleRepository.new.find(id))
-      end
-    end
-    EXPECTED_CONTENT
-
-    assert_file 'app/actions/show_article_action.rb' do |generated_content|
-      assert_equal expected_content, generated_content
-    end
-  end
-
-  test "generator creates app/actions/create_article_action.rb" do
-    run_generator
-
-    expected_content = <<~EXPECTED_CONTENT
-    class CreateArticleAction < Upgrow::Action
-      result :article
-
-      def perform(input)
-        if input.valid?
-          article = ArticleRepository.new.create(input)
-          result.success(article: article)
-        else
-          result.failure(input.errors)
-        end
-      end
-    end
-    EXPECTED_CONTENT
-
-    assert_file 'app/actions/create_article_action.rb' do |generated_content|
-      assert_equal expected_content, generated_content
     end
   end
 end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -14,6 +14,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
 
     files_created_by_generator = (files_after_generator - files_before_generator).sort
     expected_files_created_by_generator = %w(
+      app/actions/create_article_action.rb
       app/actions/show_article_action.rb
       app/inputs/article_input.rb
       app/models/article.rb
@@ -131,6 +132,29 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     EXPECTED_CONTENT
 
     assert_file 'app/actions/show_article_action.rb' do |generated_content|
+      assert_equal expected_content, generated_content
+    end
+  end
+
+  test "generator creates app/actions/create_article_action.rb" do
+    run_generator
+
+    expected_content = <<~EXPECTED_CONTENT
+    class CreateArticleAction < Upgrow::Action
+      result :article
+
+      def perform(input)
+        if input.valid?
+          article = ArticleRepository.new.create(input)
+          result.success(article: article)
+        else
+          result.failure(input.errors)
+        end
+      end
+    end
+    EXPECTED_CONTENT
+
+    assert_file 'app/actions/create_article_action.rb' do |generated_content|
       assert_equal expected_content, generated_content
     end
   end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -6,9 +6,9 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   destination Rails.root.join('tmp/generators')
   setup :prepare_destination
 
-  # test "generator runs without errors" do
-  #   assert_nothing_raised do
-  #     run_generator ["arguments"]
-  #   end
-  # end
+  test "generator runs without errors" do
+    assert_nothing_raised do
+      run_generator ["arguments"]
+    end
+  end
 end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -14,7 +14,7 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       app/inputs/article_input.rb
       app/models/article.rb
       app/records/article_record.rb
-      app/repositories/articles_repository.rb
+      app/repositories/article_repository.rb
     )
   end
 

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -18,10 +18,14 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     )
   end
 
+  def files_in_generator_destination
+    Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+  end
+
   test "generator creates only expected files" do
-    files_before_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+    files_before_generator = files_in_generator_destination
     run_generator
-    files_after_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+    files_after_generator = files_in_generator_destination
 
     files_created_by_generator = (files_after_generator - files_before_generator).sort
     assert_equal files_expected_to_be_created_by_generator, files_created_by_generator

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -5,10 +5,29 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   tests UpgrowScaffoldGenerator
   destination Rails.root.join('tmp/generators')
   setup :prepare_destination
+  arguments %w(article title:string body:text)
 
-  test "generator runs without errors" do
-    assert_nothing_raised do
-      run_generator ["arguments"]
+  test "generator creates only expected files" do
+    files_before_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+    run_generator
+    files_after_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
+
+    files_created_by_generator = (files_after_generator - files_before_generator).sort
+    expected_files_created_by_generator = %w(app/records/article_record.rb)
+    assert_equal expected_files_created_by_generator, files_created_by_generator
+  end
+
+  test "generator creates app/records/article_record.rb" do
+    run_generator
+
+    assert_file 'app/records/article_record.rb' do |generated_content|
+      expected_content = <<~EXPECTED_CONTENT
+      class ArticleRecord < ApplicationRecord
+        self.table_name = 'articles'
+      end
+      EXPECTED_CONTENT
+
+      assert_equal expected_content, generated_content
     end
   end
 end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -25,13 +25,13 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   test "generator creates app/records/article_record.rb" do
     run_generator
 
-    assert_file 'app/records/article_record.rb' do |generated_content|
-      expected_content = <<~EXPECTED_CONTENT
-      class ArticleRecord < ApplicationRecord
-        self.table_name = 'articles'
-      end
-      EXPECTED_CONTENT
+    expected_content = <<~EXPECTED_CONTENT
+    class ArticleRecord < ApplicationRecord
+      self.table_name = 'articles'
+    end
+    EXPECTED_CONTENT
 
+    assert_file 'app/records/article_record.rb' do |generated_content|
       assert_equal expected_content, generated_content
     end
   end
@@ -39,42 +39,42 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   test "generator creates app/repositories/articles_repository.rb" do
     run_generator
 
-    assert_file 'app/repositories/articles_repository.rb' do |generated_content|
-      expected_content = <<~EXPECTED_CONTENT
-      class ArticleRepository
-        def all
-          ArticleRecord.all.map { |record| to_model(record.attributes) }
-        end
-
-        def create(input)
-          record = ArticleRecord.create!(title: input.title, body: input.body)
-          to_model(record.attributes)
-        end
-
-        def find(id)
-          record = ArticleRecord.find(id)
-          to_model(record.attributes)
-        end
-
-        def update(id, input)
-          record = ArticleRecord.find(id)
-          record.update!(title: input.title, body: input.body)
-          to_model(record.attributes)
-        end
-
-        def delete(id)
-          record = ArticleRecord.find(id)
-          record.destroy!
-        end
-
-        private
-
-        def to_model(attributes)
-          Article.new(**attributes.symbolize_keys)
-        end
+    expected_content = <<~EXPECTED_CONTENT
+    class ArticleRepository
+      def all
+        ArticleRecord.all.map { |record| to_model(record.attributes) }
       end
-      EXPECTED_CONTENT
 
+      def create(input)
+        record = ArticleRecord.create!(title: input.title, body: input.body)
+        to_model(record.attributes)
+      end
+
+      def find(id)
+        record = ArticleRecord.find(id)
+        to_model(record.attributes)
+      end
+
+      def update(id, input)
+        record = ArticleRecord.find(id)
+        record.update!(title: input.title, body: input.body)
+        to_model(record.attributes)
+      end
+
+      def delete(id)
+        record = ArticleRecord.find(id)
+        record.destroy!
+      end
+
+      private
+
+      def to_model(attributes)
+        Article.new(**attributes.symbolize_keys)
+      end
+    end
+    EXPECTED_CONTENT
+
+    assert_file 'app/repositories/articles_repository.rb' do |generated_content|
       assert_equal expected_content, generated_content
     end
   end
@@ -82,15 +82,15 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
   test "generator creates app/inputs/article_input.rb" do
     run_generator
 
+    expected_content = <<~EXPECTED_CONTENT
+    class ArticleInput
+      include ActiveModel::Model
+
+      attr_accessor :title, :body
+    end
+    EXPECTED_CONTENT
+
     assert_file 'app/inputs/article_input.rb' do |generated_content|
-      expected_content = <<~EXPECTED_CONTENT
-      class ArticleInput
-        include ActiveModel::Model
-
-        attr_accessor :title, :body
-      end
-      EXPECTED_CONTENT
-
       assert_equal expected_content, generated_content
     end
   end
@@ -98,22 +98,20 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
 
   test "generator creates app/models/article.rb" do
     run_generator
+    expected_content = <<~EXPECTED_CONTENT
+    class Article
+      attr_reader :id, :title, :body, :created_at, :updated_at
 
-    assert_file 'app/models/article.rb' do |generated_content|
-      expected_content = <<~EXPECTED_CONTENT
-      class Article
-        attr_reader :id, :title, :body, :created_at, :updated_at
-
-        def initialize(id:, title:, body:, created_at:, updated_at:)
-          @id = id
-          @title = title
-          @body = body
-          @created_at = created_at
-          @updated_at = updated_at
-        end
+      def initialize(id:, title:, body:, created_at:, updated_at:)
+        @id = id
+        @title = title
+        @body = body
+        @created_at = created_at
+        @updated_at = updated_at
       end
-      EXPECTED_CONTENT
-
+    end
+    EXPECTED_CONTENT
+    assert_file 'app/models/article.rb' do |generated_content|
       assert_equal expected_content, generated_content
     end
   end

--- a/test/lib/generators/upgrow_scaffold_generator_test.rb
+++ b/test/lib/generators/upgrow_scaffold_generator_test.rb
@@ -13,7 +13,10 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
     files_after_generator = Dir.glob("#{destination_root}/**/*").select { |path| File.file?(path) }.map { |path| path.gsub(destination_root.to_s, '').slice(1..-1) }
 
     files_created_by_generator = (files_after_generator - files_before_generator).sort
-    expected_files_created_by_generator = %w(app/records/article_record.rb)
+    expected_files_created_by_generator = %w(
+      app/records/article_record.rb
+      app/repositories/articles_repository.rb
+    )
     assert_equal expected_files_created_by_generator, files_created_by_generator
   end
 
@@ -24,6 +27,41 @@ class UpgrowScaffoldGeneratorTest < Rails::Generators::TestCase
       expected_content = <<~EXPECTED_CONTENT
       class ArticleRecord < ApplicationRecord
         self.table_name = 'articles'
+      end
+      EXPECTED_CONTENT
+
+      assert_equal expected_content, generated_content
+    end
+  end
+
+  test "generator creates app/repositories/articles_repository.rb" do
+    run_generator
+
+    assert_file 'app/repositories/articles_repository.rb' do |generated_content|
+      expected_content = <<~EXPECTED_CONTENT
+      class ArticleRepository
+        def all
+          ArticleRecord.all
+        end
+
+        def create(title:, body:)
+          ArticleRecord.create!(title: title, body: body)
+        end
+
+        def find(id)
+          ArticleRecord.find(id)
+        end
+
+        def update(id, title:, body:)
+          record = find(id)
+          record.update!(title: title, body: body)
+          record
+        end
+
+        def delete(id)
+          record = find(id)
+          record.destroy!
+        end
       end
       EXPECTED_CONTENT
 


### PR DESCRIPTION
This PR adds an `upgrow_scaffold` generator which can reproduce the content of the code in `test/dummy`. The purpose is to enable faster experimentation by new users of the upgrow patterns.

There are a few pieces missing at the moment, which can either be addressed in this PR, or subsequent ones:
- [ ] Migrations
- [ ] Routes

The generator does not add validations to match the code in `test/dummy` and probably should not.

Test coverage is reached by explicitly comparing generated content with the files in `test/dummy`.