### PR TITLE
Prevent conditional validations with Upgrow

### DIFF
--- a/lib/upgrow.rb
+++ b/lib/upgrow.rb
@@ -9,6 +9,8 @@ require_relative 'upgrow/input'
 require_relative 'upgrow/model'
 require_relative 'upgrow/result'
 
+require_relative 'upgrow/rails_extensions/prevent_conditional_validations'
+
 # The gem's main namespace.
 module Upgrow
 end

--- a/lib/upgrow/input.rb
+++ b/lib/upgrow/input.rb
@@ -36,12 +36,5 @@ module Upgrow
       @errors = ActiveModel::Errors.new(self)
       super(**attributes.to_hash.transform_keys(&:to_sym))
     end
-
-    private
-
-    # Overwrites the validation context writer so the Input's state is not
-    # mutated.
-    def validation_context=(_)
-    end
   end
 end

--- a/lib/upgrow/rails_extensions/prevent_conditional_validations.rb
+++ b/lib/upgrow/rails_extensions/prevent_conditional_validations.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Upgrow
+  module RailsExtensions
+    class ConditionalValidationsNotPermitted < StandardError
+    end
+
+    # Rails provides for conditional validations by accepting the `on`
+    # parameter to the validation macro.
+    # See https://github.com/rails/rails/blob/main/activemodel/lib/active_model/validations.rb#L72-L73
+    # Because we want inputs to be backed by ActiveModel, but also immutable,
+    # we can't support conditional validations. Removing conditional validations
+    # aligns nicely with the Upgrow patterns anyway, so this is a clear win.
+    module PreventConditionalValidations
+      private
+
+      # Raise when conditional validations are used as part of Upgrow.
+      def validation_context=(context)
+        raise ConditionalValidationsNotPermitted if context
+      end
+    end
+  end
+end
+
+Upgrow::Input.prepend(Upgrow::RailsExtensions::PreventConditionalValidations)

--- a/test/upgrow/rails_extensions/prevent_conditional_validations_test.rb
+++ b/test/upgrow/rails_extensions/prevent_conditional_validations_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Upgrow
+  module RailsExtensions
+    class PreventConditionalValidationsTest < ActiveSupport::TestCase
+      class PreventConditionalValidationsTestModel < Upgrow::Input
+        attribute :title
+        validates :title, presence: true, on: :new
+      end
+
+      test 'conditional validations raise an exception' do
+        assert_raises(ConditionalValidationsNotPermitted) do
+          PreventConditionalValidationsTestModel.new.valid?(:new)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/Shopify/upgrow/issues/32

This PR addresses two issues with the current implementation of keeping
Upgrow::Input immutable:
1. It raises Ruby warnings (discussed in issue)
2. It isn't very clear why the method is being overwritten

By using Ruby's method lookup system, we can address issue 1.

By using well named classes with documentation we can address issue 2.